### PR TITLE
Address build warnings

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -42,10 +42,3 @@ jobs:
           SIGNING_KEY: signingkey
           SIGNING_KEY_ID: signingkeyid
           SONATYPE_STAGING_PROFILE_ID: profileid
-      - name: Upload test reports
-        if: success() || failure()
-        uses: actions/upload-artifact@v3
-        with:
-          name: test-reports
-          path: |
-            MiddleEllipsisText/build/reports/androidTests/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-
       - name: Setup Android SDK

--- a/MiddleEllipsisText/build.gradle.kts
+++ b/MiddleEllipsisText/build.gradle.kts
@@ -16,6 +16,8 @@ android {
       }
     }
   }
+
+  namespace = "io.github.mataku.middleellipsistext"
 }
 
 dependencies {

--- a/MiddleEllipsisText/src/main/AndroidManifest.xml
+++ b/MiddleEllipsisText/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="io.github.mataku.middleellipsistext">
+<manifest>
 
 </manifest>

--- a/build-logic/convention/src/main/java/ext/KotlinConfiguration.kt
+++ b/build-logic/convention/src/main/java/ext/KotlinConfiguration.kt
@@ -9,7 +9,7 @@ fun CommonExtension<*, *, *, *>.kotlinConfiguration() {
     targetCompatibility = JavaVersion.VERSION_11
   }
   (this as ExtensionAware).extensions.configure<KotlinJvmOptions>("kotlinOptions") {
-    jvmTarget = "1.8"
+    jvmTarget = "11"
     freeCompilerArgs = freeCompilerArgs + listOf("-opt-in=kotlin.RequiresOptIn")
   }
 }


### PR DESCRIPTION
- Use java 11 on compileKoltin task
- Use namespace in build.gradle instead of package in androidManifest.xml